### PR TITLE
Public split and improvements to visit speed

### DIFF
--- a/treap.go
+++ b/treap.go
@@ -100,7 +100,7 @@ func (t *Treap) union(this *node, that *node) *node {
 	}
 }
 
-// Splits a treap into two treaps based on a split item "s".
+// Splits a treap into three treaps based on a split item "s".
 // The result tuple-3 means (left, X, right), where X is either...
 // nil - meaning the item s was not in the original treap.
 // non-nil - returning a treap with a single node having item s.
@@ -180,7 +180,7 @@ func (t *Treap) join(this *node, that *node) *node {
 
 type ItemVisitor func(i Item) bool
 
-// Visit items greater-than-or-equal to the pivot.
+// Visit items greater-than-or-equal to the pivot.  If the pivot is null, this visits all items in ascending order.
 func (t *Treap) VisitAscend(pivot Item, visitor ItemVisitor) {
 	t.visitAscend(t.root, pivot, visitor)
 }
@@ -189,13 +189,37 @@ func (t *Treap) visitAscend(n *node, pivot Item, visitor ItemVisitor) bool {
 	if n == nil {
 		return true
 	}
-	if t.compare(pivot, n.item) <= 0 {
+	if pivot == nil || t.compare(pivot, n.item) <= 0 {
 		if !t.visitAscend(n.left, pivot, visitor) {
 			return false
 		}
 		if !visitor(n.item) {
 			return false
 		}
+		//since n.right is > n.item by the comparison, we can speed up by not comparing
+		return t.visitAscend(n.right, nil, visitor)
 	}
 	return t.visitAscend(n.right, pivot, visitor)
+}
+
+// Visit items less-than-or-equal to the pivot.  If the pivot is null, this visits all items in descending order.
+func (t *Treap) VisitDescend(pivot Item, visitor ItemVisitor) {
+	t.visitDescend(t.root, pivot, visitor)
+}
+
+func (t *Treap) visitDescend(n *node, pivot Item, visitor ItemVisitor) bool {
+	if n == nil {
+		return true
+	}
+	if pivot == nil || t.compare(pivot, n.item) >= 0 {
+		if !t.visitDescend(n.right, pivot, visitor) {
+			return false
+		}
+		if !visitor(n.item) {
+			return false
+		}
+		//since n.left is < n.item by the comparison, we can speed up by not comparing
+		return t.visitDescend(n.left, nil, visitor)
+	}
+	return t.visitDescend(n.left, pivot, visitor)
 }

--- a/treap.go
+++ b/treap.go
@@ -103,9 +103,26 @@ func (t *Treap) union(this *node, that *node) *node {
 // Splits a treap into two treaps based on a split item "s".
 // The result tuple-3 means (left, X, right), where X is either...
 // nil - meaning the item s was not in the original treap.
-// non-nil - returning the node that had item s.
-// The tuple-3's left result treap has items < s,
-// and the tuple-3's right result treap has items > s.
+// non-nil - returning a treap with a single node having item s.
+// The tuple-3's left result has items < s,
+// and the tuple-3's right result has items > s.
+func (t *Treap) Split(s Item) (*Treap, *Treap, *Treap) {
+	nleft, nmiddle, nright := t.split(t.root, s)
+
+	left := &Treap{compare: t.compare, root: nleft}
+	var middle *Treap
+	if nmiddle != nil {
+		middle = &Treap{compare: t.compare, root: &node{
+			item:     nmiddle.item,
+			priority: nmiddle.priority,
+			left:     nil,
+			right:    nil,
+		}}
+	}
+	right := &Treap{compare: t.compare, root: nright}
+	return left, middle, right
+}
+
 func (t *Treap) split(n *node, s Item) (*node, *node, *node) {
 	if n == nil {
 		return nil, nil, nil

--- a/treap_test.go
+++ b/treap_test.go
@@ -96,7 +96,7 @@ func load(x *Treap, arr []string) *Treap {
 	return x
 }
 
-func visitExpect(t *testing.T, x *Treap, start string, arr []string) {
+func visitExpect(t *testing.T, x *Treap, start Item, arr []string) {
 	n := 0
 	x.VisitAscend(start, func(i Item) bool {
 		if i.(string) != arr[n] {
@@ -118,6 +118,7 @@ func TestVisit(t *testing.T) {
 
 	visitX := func() {
 		visitExpect(t, x, "a", []string{"a", "b", "c", "d", "e"})
+		visitExpect(t, x, nil, []string{"a", "b", "c", "d", "e"})
 		visitExpect(t, x, "a1", []string{"b", "c", "d", "e"})
 		visitExpect(t, x, "b", []string{"b", "c", "d", "e"})
 		visitExpect(t, x, "b1", []string{"c", "d", "e"})
@@ -137,6 +138,7 @@ func TestVisit(t *testing.T) {
 	y = y.Delete("c")
 
 	visitExpect(t, y, "a", []string{"b", "cc", "d", "e", "f"})
+	visitExpect(t, y, nil, []string{"b", "cc", "d", "e", "f"})
 	visitExpect(t, y, "a1", []string{"b", "cc", "d", "e", "f"})
 	visitExpect(t, y, "b", []string{"b", "cc", "d", "e", "f"})
 	visitExpect(t, y, "b1", []string{"cc", "d", "e", "f"})
@@ -222,4 +224,76 @@ func TestVisitEndEarly(t *testing.T) {
 	}
 	visitX()
 
+}
+
+func visitDescendExpect(t *testing.T, x *Treap, start Item, arr []string) {
+	n := 0
+	x.VisitDescend(start, func(i Item) bool {
+		if i.(string) != arr[n] {
+			t.Errorf("expected visit item: %v, saw: %v (%v)", arr[n], i, arr)
+		}
+		n++
+		return true
+	})
+	if n != len(arr) {
+		t.Errorf("expected # visit callbacks: %v, saw: %v", len(arr), n)
+	}
+}
+
+func TestVisitDescend(t *testing.T) {
+	x := NewTreap(stringCompare)
+	visitDescendExpect(t, x, "a", []string{})
+
+	x = load(x, []string{"e", "d", "c", "c", "a", "b", "a"})
+
+	visitX := func() {
+		visitDescendExpect(t, x, "a", []string{"a"})
+		visitDescendExpect(t, x, "a1", []string{"a"})
+		visitDescendExpect(t, x, "b", []string{"b", "a"})
+		visitDescendExpect(t, x, "b1", []string{"b", "a"})
+		visitDescendExpect(t, x, "c", []string{"c", "b", "a"})
+		visitDescendExpect(t, x, "c1", []string{"c", "b", "a"})
+		visitDescendExpect(t, x, "d", []string{"d", "c", "b", "a"})
+		visitDescendExpect(t, x, "d1", []string{"d", "c", "b", "a"})
+		visitDescendExpect(t, x, "e", []string{"e", "d", "c", "b", "a"})
+		visitDescendExpect(t, x, "f", []string{"e", "d", "c", "b", "a"})
+		visitDescendExpect(t, x, nil, []string{"e", "d", "c", "b", "a"})
+	}
+	visitX()
+
+	var y *Treap
+	y = x.Upsert("f", 1)
+	y = y.Delete("a")
+	y = y.Upsert("cc", 2)
+	y = y.Delete("c")
+
+	visitDescendExpect(t, y, "a", []string{})
+	visitDescendExpect(t, y, "a1", []string{})
+	visitDescendExpect(t, y, "b", []string{"b"})
+	visitDescendExpect(t, y, "b1", []string{"b"})
+	visitDescendExpect(t, y, "c", []string{"b"})
+	visitDescendExpect(t, y, "c1", []string{"b"})
+	visitDescendExpect(t, y, "cd", []string{"cc", "b"})
+	visitDescendExpect(t, y, "d", []string{"d", "cc", "b"})
+	visitDescendExpect(t, y, "d1", []string{"d", "cc", "b"})
+	visitDescendExpect(t, y, "e", []string{"e", "d", "cc", "b"})
+	visitDescendExpect(t, y, "f", []string{"f", "e", "d", "cc", "b"})
+	visitDescendExpect(t, y, "z", []string{"f", "e", "d", "cc", "b"})
+	visitDescendExpect(t, y, nil, []string{"f", "e", "d", "cc", "b"})
+
+	// The x treap should be unchanged.
+	visitX()
+
+	if x.Min() != "a" {
+		t.Errorf("expected min of a")
+	}
+	if x.Max() != "e" {
+		t.Errorf("expected max of d")
+	}
+	if y.Min() != "b" {
+		t.Errorf("expected min of b")
+	}
+	if y.Max() != "f" {
+		t.Errorf("expected max of f")
+	}
 }


### PR DESCRIPTION
Hi,

I have a use case where we need to store timestamped data, split off everything before `time.Now()`, then iterate that split in ascending order in its entirety.  I've made a couple improvements to the treap to accomplish this.  Would you like to merge them back in?

The nil pivot short-circuit around the compare method was yielding about a 35% increase in performance for my particular use case.  My comparison function is about as simple as you can compare timestamps:

``` go
func compare(a, b interface{}) int {
    pA := a.(myItem)
    pB := b.(myItem)

    if pA.Timestamp.Equal(pB.Timestamp) {
        return 0
    }
    if pA.Timestamp.Before(pB.Timestamp) {
        return -1
    }
    return 1
}
```
